### PR TITLE
Feature/workspace 자잘한 IDE 에러 개선

### DIFF
--- a/src/main/java/com/dakgu/siack/file/service/LocalFileService.java
+++ b/src/main/java/com/dakgu/siack/file/service/LocalFileService.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 public class LocalFileService implements FileService {
 
     private final String uploadPath;
-    private static final Set<String> IMAGE_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
     public LocalFileService(@Value("${file.local.upload-path:uploads}") String uploadPath) {
         this.uploadPath = uploadPath;
@@ -59,19 +58,4 @@ public class LocalFileService implements FileService {
         }
     }
 
-    private String getFileCategory(String extension) {
-        if (IMAGE_EXTENSIONS.contains(extension)) return "images";
-        throw new IllegalArgumentException("지원하지 않는 파일 형식입니다: " + extension);
-    }
-
-    /**
-     * 파일명에서 확장자를 추출합니다.
-     * @param filename 원본 파일명
-     * @return 확장자 (없으면 빈 문자열)
-     */
-    private String getExtension(String filename) {
-        if (filename == null) return "";
-        int idx = filename.lastIndexOf('.');
-        return (idx > 0 && idx < filename.length() - 1) ? filename.substring(idx + 1).toLowerCase() : "";
-    }
 }

--- a/src/main/java/com/dakgu/siack/user/service/UserService.java
+++ b/src/main/java/com/dakgu/siack/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.dakgu.siack.user.service;
 
 import com.dakgu.siack.config.jwt.JwtTokenProvider;
 import com.dakgu.siack.file.repository.SdfFileRepository;
-import com.dakgu.siack.file.service.FileService;
 import com.dakgu.siack.file.service.FileUploadService;
 import com.dakgu.siack.log.service.UserLogService;
 import com.dakgu.siack.log.vo.UserLog;
@@ -44,7 +43,6 @@ public class UserService {
     private final UserValidationService userValidationService;
     private final FileUploadService uploadService;
     private final SdfFileRepository fileRepository;
-    private final FileService fileService;
     private final UserLogService userLogService;
 
     /* username 사용 가능한지 확인 */
@@ -344,7 +342,13 @@ public class UserService {
         return new ResponseDTO(HttpStatus.OK.value(), "프로필 이미지가 성공적으로 업데이트되었습니다.");
     }
 
-
+    /**
+     * 주어진 사용자 ID(userid)로 해당 사용자의 프로필 이미지 URL을 조회합니다.
+     * 프로필 이미지가 없거나 사용자가 존재하지 않으면 적절한 메시지를 반환합니다.
+     *
+     * @param userid 조회할 사용자 ID (String)
+     * @return UserProfileUrlResponseDTO (프로필 이미지 URL 및 메시지)
+     */
     public UserProfileUrlResponseDTO getUserProfileURL(String userid) {
         User user = userRepository.findByUseridAndUseyn(Long.valueOf(userid), true);
         if (user == null) {

--- a/src/main/java/com/dakgu/siack/workspace/dto/CreateWorkspaceRequestDTO.java
+++ b/src/main/java/com/dakgu/siack/workspace/dto/CreateWorkspaceRequestDTO.java
@@ -1,9 +1,6 @@
 package com.dakgu.siack.workspace.dto;
 
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-
 @Data
 public class CreateWorkspaceRequestDTO {
     private String name;

--- a/src/main/java/com/dakgu/siack/workspace/dto/GetWorkspaceResponseDTO.java
+++ b/src/main/java/com/dakgu/siack/workspace/dto/GetWorkspaceResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = true)
 @Builder
 @Data
 @AllArgsConstructor

--- a/src/main/java/com/dakgu/siack/workspace/dto/ModifyWorkspaceRequestDTO.java
+++ b/src/main/java/com/dakgu/siack/workspace/dto/ModifyWorkspaceRequestDTO.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ModifyWorkspaceRequestDTO {
     private Long workspaceId;
-    private Long userId;
     private String name;
     private String description;
 }


### PR DESCRIPTION
이번 풀 리퀘스트는 여러 서비스 클래스와 DTO 클래스 전반의 코드 정리와 리팩토링에 중점을 두고 있으며, 코드베이스 단순화 및 사용되지 않거나 중복된 요소 제거를 목표로 합니다. 또한 DTO의 일관성과 문서화를 개선했습니다.

코드 정리 및 단순화
- LocalFileService에서 사용되지 않는 헬퍼 메서드(getFileCategory, getExtension)와 IMAGE_EXTENSIONS 상수를 제거하여 파일 서비스 구현을 간소화했습니다.
- UserService에서 사용되지 않는 FileService 필드와 해당 import를 제거하여 불필요한 의존성을 줄였습니다. 
- ModifyWorkspaceRequestDTO에서 사용되지 않는 userId 필드를 제거하여 요청 구조를 명확히 했습니다.

DTO 개선
- GetWorkspaceResponseDTO에 EqualsAndHashCode(callSuper = true)를 추가하여 동등성 검사와 일관성을 개선했습니다.
- CreateWorkspaceRequestDTO에서 불필요한 Lombok 애노테이션(Getter, Setter)을 제거하고, Data만 사용하여 코드를 단순화했습니다.

문서화
- UserService의 getUserProfileURL 메서드에 상세한 Javadoc을 추가하여 코드 가독성과 개발자 가이드를 개선했습니다.