### PR TITLE
채널 및 워크스페이스 멤버 관리 기능 추가

### DIFF
--- a/src/main/java/com/dakgu/siack/workspace/controller/ChannelController.java
+++ b/src/main/java/com/dakgu/siack/workspace/controller/ChannelController.java
@@ -1,0 +1,26 @@
+package com.dakgu.siack.workspace.controller;
+
+import com.dakgu.siack.utils.ResponseDTO;
+import com.dakgu.siack.workspace.dto.CreateChannelRequestDTO;
+import com.dakgu.siack.workspace.service.ChannelRequestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/channel")
+@RequiredArgsConstructor
+public class ChannelController {
+
+    private final ChannelRequestService channelRequestService;
+
+    @PostMapping("/{workspaceId}/create")
+    public ResponseEntity<?> createChannel(Authentication authentication,
+                                           @PathVariable("workspaceId") Long workspaceId,
+                                           @RequestBody CreateChannelRequestDTO request) {
+        ResponseDTO response = channelRequestService.createChannel(authentication, workspaceId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/dakgu/siack/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/dakgu/siack/workspace/controller/WorkspaceController.java
@@ -4,7 +4,9 @@ import com.dakgu.siack.utils.ResponseDTO;
 import com.dakgu.siack.workspace.dto.CreateWorkspaceRequestDTO;
 import com.dakgu.siack.workspace.dto.GetWorkspaceResponseDTO;
 import com.dakgu.siack.workspace.dto.ModifyWorkspaceRequestDTO;
+import com.dakgu.siack.workspace.dto.InviteWorkspaceMemberRequestDTO;
 import com.dakgu.siack.workspace.service.WorkspaceRequestService;
+import com.dakgu.siack.workspace.service.WorkspaceMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -19,6 +21,7 @@ import java.util.List;
 public class WorkspaceController {
 
     private final WorkspaceRequestService workspaceRequestService;
+    private final WorkspaceMemberService workspaceMemberService; // 멤버 초대/추방 서비스 주입
 
     @PostMapping("/create")
     public ResponseEntity<?> createWorkspace(Authentication authentication, @RequestBody CreateWorkspaceRequestDTO request) {
@@ -49,10 +52,24 @@ public class WorkspaceController {
             Authentication authentication,
             @PathVariable("workspaceId") Long workspaceId,
             @RequestPart("file") MultipartFile file
-        ) throws java.io.IOException {
+    ) throws java.io.IOException {
         ResponseDTO response = workspaceRequestService.uploadWorkspaceImage(authentication, file, workspaceId);
         return ResponseEntity.status(200).body(response);
     }
 
+    @PostMapping("/{workspaceId}/members/invite")
+    public ResponseEntity<?> inviteMember(Authentication authentication,
+                                          @PathVariable("workspaceId") Long workspaceId,
+                                          @RequestBody InviteWorkspaceMemberRequestDTO request) {
+        ResponseDTO response = workspaceMemberService.inviteMember(authentication, workspaceId, request);
+        return ResponseEntity.status(200).body(response);
+    }
 
+    @DeleteMapping("/{workspaceId}/members/{userId}")
+    public ResponseEntity<?> removeMember(Authentication authentication,
+                                          @PathVariable("workspaceId") Long workspaceId,
+                                          @PathVariable("userId") Long userId) {
+        ResponseDTO response = workspaceMemberService.removeMember(authentication, workspaceId, userId);
+        return ResponseEntity.status(200).body(response);
+    }
 }

--- a/src/main/java/com/dakgu/siack/workspace/dto/CreateChannelRequestDTO.java
+++ b/src/main/java/com/dakgu/siack/workspace/dto/CreateChannelRequestDTO.java
@@ -1,0 +1,21 @@
+package com.dakgu.siack.workspace.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 채널 생성 요청 DTO
+ * name        : 채널 이름 (필수)
+ * description : 채널 설명 (선택)
+ * isPrivate   : 비공개 여부 (기본 false)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateChannelRequestDTO {
+    private String name;
+    private String description;
+    private boolean isPrivate = false;
+}
+

--- a/src/main/java/com/dakgu/siack/workspace/dto/InviteWorkspaceMemberRequestDTO.java
+++ b/src/main/java/com/dakgu/siack/workspace/dto/InviteWorkspaceMemberRequestDTO.java
@@ -1,0 +1,19 @@
+package com.dakgu.siack.workspace.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 워크스페이스 멤버 초대 요청 DTO
+ * userId : 초대할 사용자 ID (필수)
+ * role   : 부여할 역할 (선택, 기본 MEMBER)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class InviteWorkspaceMemberRequestDTO {
+    private Long userId;
+    private String role = "MEMBER";
+}
+

--- a/src/main/java/com/dakgu/siack/workspace/repository/ChannelRepository.java
+++ b/src/main/java/com/dakgu/siack/workspace/repository/ChannelRepository.java
@@ -4,5 +4,5 @@ import com.dakgu.siack.workspace.vo.ChannelVO;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelRepository extends JpaRepository<ChannelVO, Long> {
+    boolean existsByWorkspace_WorkspaceIdAndNameIgnoreCase(Long workspaceId, String name);
 }
-

--- a/src/main/java/com/dakgu/siack/workspace/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/dakgu/siack/workspace/repository/WorkspaceMemberRepository.java
@@ -5,6 +5,7 @@ import com.dakgu.siack.workspace.vo.WorkspaceMemberId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMemberVO, WorkspaceMemberId> {
@@ -12,4 +13,6 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
     List<WorkspaceMemberVO> findByUser_Userid(Long userid);
     // 특정 워크스페이스의 모든 멤버 조회
     List<WorkspaceMemberVO> findByWorkspace_WorkspaceId(Long workspaceId);
+    // 특정 워크스페이스 + 사용자 조합 조회 (채널 생성 등 권한 확인 용)
+    Optional<WorkspaceMemberVO> findByWorkspace_WorkspaceIdAndUser_Userid(Long workspaceId, Long userId);
 }

--- a/src/main/java/com/dakgu/siack/workspace/service/ChannelRequestService.java
+++ b/src/main/java/com/dakgu/siack/workspace/service/ChannelRequestService.java
@@ -1,0 +1,95 @@
+package com.dakgu.siack.workspace.service;
+
+import com.dakgu.siack.user.service.UserService;
+import com.dakgu.siack.user.vo.User;
+import com.dakgu.siack.utils.ResponseDTO;
+import com.dakgu.siack.workspace.dto.CreateChannelRequestDTO;
+import com.dakgu.siack.workspace.repository.*;
+import com.dakgu.siack.workspace.vo.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChannelRequestService {
+
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final ChannelRepository channelRepository;
+    private final ChannelMemberRepository channelMemberRepository;
+    private final UserService userService;
+
+    /**
+     * 워크스페이스 내 채널을 생성합니다.
+     * 1) 인증된 유저 확인
+     * 2) 워크스페이스 존재/활성 여부 확인
+     * 3) 유저가 해당 워크스페이스 멤버인지 확인
+     * 4) 채널 이름 중복(대소문자 무시) 방지
+     * 5) 채널 생성 및 생성자를 ADMIN 권한 멤버로 추가
+     *
+     * @param authentication 인증 객체
+     * @param workspaceId 채널을 생성할 워크스페이스 ID
+     * @param request 채널 생성 요청 DTO (name 필수)
+     * @return ResponseDTO (201 성공, 400 잘못된 요청, 403 권한없음, 409 중복이름)
+     */
+    @Transactional
+    public ResponseDTO createChannel(Authentication authentication, Long workspaceId, CreateChannelRequestDTO request) {
+        User user = Optional.ofNullable(userService.getUserFromAuthentication(authentication))
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        if (workspaceId == null) {
+            return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "워크스페이스 ID가 필요합니다.");
+        }
+        if (request == null || request.getName() == null || request.getName().trim().isEmpty()) {
+            return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "채널 이름은 필수입니다.");
+        }
+        String normalizedName = request.getName().trim();
+
+        WorkspaceVO workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new IllegalArgumentException("워크스페이스를 찾을 수 없습니다."));
+        if (!workspace.isStatus()) {
+            return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "삭제된 워크스페이스입니다.");
+        }
+
+        // 워크스페이스 멤버 여부 확인
+        boolean isMember = workspaceMemberRepository
+                .findByWorkspace_WorkspaceIdAndUser_Userid(workspaceId, user.getUserid())
+                .filter(WorkspaceMemberVO::isStatus)
+                .isPresent();
+        if (!isMember) {
+            return new ResponseDTO(HttpStatus.FORBIDDEN.value(), "워크스페이스 멤버만 채널을 생성할 수 있습니다.");
+        }
+
+        // 이름 중복 검사 (동일 워크스페이스 내 case-insensitive)
+        if (channelRepository.existsByWorkspace_WorkspaceIdAndNameIgnoreCase(workspaceId, normalizedName)) {
+            return new ResponseDTO(HttpStatus.CONFLICT.value(), "이미 존재하는 채널 이름입니다.");
+        }
+
+        ChannelVO channel = ChannelVO.builder()
+                .workspace(workspace)
+                .name(normalizedName)
+                .description(request.getDescription())
+                .isPrivate(request.isPrivate())
+                .status(true)
+                .build();
+        channelRepository.save(channel);
+
+        ChannelMemberVO creatorMembership = ChannelMemberVO.builder()
+                .channel(channel)
+                .user(user)
+                .role("ADMIN")
+                .status(true)
+                .build();
+        channelMemberRepository.save(creatorMembership);
+
+        return new ResponseDTO(HttpStatus.CREATED.value(), "채널이 생성되었습니다.");
+    }
+}
+

--- a/src/main/java/com/dakgu/siack/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/dakgu/siack/workspace/service/WorkspaceMemberService.java
@@ -1,0 +1,128 @@
+package com.dakgu.siack.workspace.service;
+
+import com.dakgu.siack.user.repository.UserRepository;
+import com.dakgu.siack.user.service.UserService;
+import com.dakgu.siack.user.vo.User;
+import com.dakgu.siack.utils.ResponseDTO;
+import com.dakgu.siack.workspace.dto.InviteWorkspaceMemberRequestDTO;
+import com.dakgu.siack.workspace.repository.WorkspaceMemberRepository;
+import com.dakgu.siack.workspace.repository.WorkspaceRepository;
+import com.dakgu.siack.workspace.vo.WorkspaceMemberVO;
+import com.dakgu.siack.workspace.vo.WorkspaceVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkspaceMemberService {
+
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    private static final Set<String> ALLOWED_ROLES = Set.of("MEMBER","ADMIN");
+
+    /**
+     * 워크스페이스 운영자(OWNER)가 멤버를 초대합니다.
+     * - 이미 활성 멤버이면 409
+     * - 비활성 멤버였다면 재활성화 및 역할 갱신
+     * - 허용되지 않은 역할이면 기본 MEMBER
+     */
+    @Transactional
+    public ResponseDTO inviteMember(Authentication authentication, Long workspaceId, InviteWorkspaceMemberRequestDTO request) {
+        User operator = getAuthUser(authentication);
+        if (workspaceId == null) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "워크스페이스 ID가 필요합니다.");
+        if (request == null || request.getUserId() == null) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "초대할 사용자 ID가 필요합니다.");
+
+        WorkspaceVO workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new IllegalArgumentException("워크스페이스를 찾을 수 없습니다."));
+        if (!workspace.isStatus()) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "삭제된 워크스페이스입니다.");
+        validateOwner(operator, workspace);
+
+        User target = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        if (!target.isUseyn()) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "비활성 사용자입니다.");
+        if (target.getUserid().equals(workspace.getOwner().getUserid())) {
+            return new ResponseDTO(HttpStatus.CONFLICT.value(), "소유자는 이미 멤버입니다.");
+        }
+
+        Optional<WorkspaceMemberVO> existingOpt = workspaceMemberRepository.findByWorkspace_WorkspaceIdAndUser_Userid(workspaceId, target.getUserid());
+        if (existingOpt.isPresent()) {
+            WorkspaceMemberVO existing = existingOpt.get();
+            if (existing.isStatus()) {
+                return new ResponseDTO(HttpStatus.CONFLICT.value(), "이미 멤버로 존재합니다.");
+            } else {
+                existing.setStatus(true);
+                existing.setRole(resolveRole(request.getRole()));
+                workspaceMemberRepository.save(existing);
+                return new ResponseDTO(HttpStatus.CREATED.value(), "비활성 멤버를 재초대했습니다.");
+            }
+        }
+
+        WorkspaceMemberVO member = WorkspaceMemberVO.builder()
+                .workspace(workspace)
+                .user(target)
+                .role(resolveRole(request.getRole()))
+                .status(true)
+                .build();
+        workspaceMemberRepository.save(member);
+
+        return new ResponseDTO(HttpStatus.CREATED.value(), "멤버가 초대되었습니다.");
+    }
+
+    /**
+     * 워크스페이스 운영자(OWNER)가 특정 멤버를 추방(비활성화)합니다.
+     */
+    @Transactional
+    public ResponseDTO removeMember(Authentication authentication, Long workspaceId, Long targetUserId) {
+        User operator = getAuthUser(authentication);
+        if (workspaceId == null || targetUserId == null) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "워크스페이스 ID와 사용자 ID가 필요합니다.");
+
+        WorkspaceVO workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new IllegalArgumentException("워크스페이스를 찾을 수 없습니다."));
+        if (!workspace.isStatus()) return new ResponseDTO(HttpStatus.BAD_REQUEST.value(), "삭제된 워크스페이스입니다.");
+        validateOwner(operator, workspace);
+
+        if (workspace.getOwner().getUserid().equals(targetUserId)) {
+            return new ResponseDTO(HttpStatus.FORBIDDEN.value(), "소유자는 추방할 수 없습니다.");
+        }
+
+        WorkspaceMemberVO membership = workspaceMemberRepository
+                .findByWorkspace_WorkspaceIdAndUser_Userid(workspaceId, targetUserId)
+                .orElse(null);
+        if (membership == null || !membership.isStatus()) {
+            return new ResponseDTO(HttpStatus.NOT_FOUND.value(), "활성 멤버가 아닙니다.");
+        }
+
+        membership.setStatus(false);
+        workspaceMemberRepository.save(membership);
+        return new ResponseDTO(HttpStatus.OK.value(), "멤버를 추방했습니다.");
+    }
+
+    private String resolveRole(String role) {
+        if (role == null) return "MEMBER";
+        String upper = role.trim().toUpperCase();
+        return ALLOWED_ROLES.contains(upper) ? upper : "MEMBER";
+    }
+
+    private User getAuthUser(Authentication authentication) {
+        return Optional.ofNullable(userService.getUserFromAuthentication(authentication))
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+    }
+
+    private void validateOwner(User operator, WorkspaceVO workspace) {
+        if (!workspace.getOwner().getUserid().equals(operator.getUserid())) {
+            throw new SecurityException("워크스페이스 소유자만 작업할 수 있습니다.");
+        }
+    }
+}
+


### PR DESCRIPTION
이 풀 리퀘스트는 채널 관리 및 워크스페이스 멤버 관리 기능을 새롭게 도입합니다. 
이를 통해 워크스페이스 내에서 채널을 생성하고, 멤버를 초대하거나 제거할 수 있는 기능이 추가되었습니다. 
해당 기능을 지원하기 위해 REST API 엔드포인트, DTO, 서비스 클래스가 구현되었으며, 필요한 리포지토리 확장도 함께 포함됩니다.

### 채널 관리
- ChannelController 및 ChannelRequestService를 추가하여 워크스페이스 내 채널 생성을 지원합니다. 채널 생성 시 워크스페이스 존재 여부, 멤버십 유효성, 채널 이름의 중복 여부(대소문자 구분 없음)에 대한 검증을 수행합니다.
- 채널 생성 요청을 위한 CreateChannelRequestDTO를 도입하여 채널명, 설명, 공개 여부를 전달할 수 있도록 하였습니다.
- ChannelRepository에 워크스페이스 내 채널 이름의 중복 여부를 확인하는 메서드를 추가하였습니다.

### 워크스페이스 멤버 관리
- WorkspaceController에 멤버 초대 및 제거를 위한 엔드포인트를 추가하고, 관련 로직을 처리하기 위해 WorkspaceMemberService를 주입하였습니다.
- 멤버 초대 요청을 위한 InviteWorkspaceMemberRequestDTO를 도입하여 사용자 식별자 및 역할을 전달할 수 있도록 하였습니다.
- WorkspaceMemberService는 멤버 초대 시 역할 부여 및 기존 멤버 재활성화를 처리하고, 멤버 제거 시 비활성화를 수행합니다. 해당 기능은 워크스페이스 소유자에게만 허용되도록 권한 제어를 적용하였습니다.
- 권한 검증 및 멤버십 확인을 위해 워크스페이스와 사용자 정보를 기반으로 멤버를 조회하는 메서드를 WorkspaceMemberRepository에 추가하였습니다.